### PR TITLE
Add runnable agent harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# hOLOVERSE.github.io
+# 3rdEye: Advanced AR Spatial Composer
+
+3rdEye is a Reality Composer–class AR creation environment that fuses Unity 2023.2 LTS, AR Foundation 5.0, and an autonomous development agent. It focuses on persistent anchors, physics-rich interaction, rapid asset ingestion, and timeline-driven animation for ARKit and ARCore deployments.
+
+## Core Pillars
+- **Spatial reliability:** Persistent anchors, robust plane detection with boundary viz, occlusion, and depth-aware sorting.
+- **Interactive creation:** Drag-and-drop placement, transform gizmos, timeline animation, undo/redo via command pattern, and hierarchical scene management.
+- **High-fidelity rendering:** URP-based lighting, dynamic shadows, selection highlights, and AR-aware occlusion materials.
+- **Asset fluency:** FBX/OBJ/GLTF/USD import with LODs, material conversion, and platform-aware texture compression.
+- **Performance discipline:** Mobile-first budgets for draw calls, physics, memory, and UI frame time.
+
+## Repository Contents
+- `docs/ARCHITECTURE.md`: Autonomous AR development agent overview.
+- `docs/3rdEye_TECH_SPEC.md`: Technical specification and delivery milestones for 3rdEye.
+- `src/agent/`: Python skeleton for the planner/RAG/policy/tooling stack that will automate Unity workflows.
+
+## Quick Start (Planning)
+1. Read `docs/3rdEye_TECH_SPEC.md` for feature scope, stack, and milestones.
+2. Use `docs/ARCHITECTURE.md` to align automation hooks with Unity build/test/export pipelines.
+3. Extend `src/agent/` modules to orchestrate Unity CLI tasks (import, build, test, export) and to integrate RAG+RL policies.
+4. Run the lightweight orchestration harness:
+
+   ```bash
+   python -m src.agent.cli "Implement plane detection with anchors" \
+     --constraint "Maintain 60 FPS" \
+     --doc "Use AR Foundation 5.0 plane subsystem"
+   ```
+
+   The CLI wires planner → RAG → policy → tool executor to provide a runnable skeleton while you replace the stubbed tools with Unity automation.
+
+## Roadmap Highlights
+- Implement Unity project layout (Assets/ Scripts/ Prefabs/ Scenes/ Tests/) per the tech spec.
+- Stand up AR session, plane detection, anchor management, and placement loop with physics and occlusion.
+- Deliver timeline animation UI, undo/redo command stack, and asset import/export (USDZ/GLB) paths.
+- Integrate autonomous agent loops for CI builds, validation, and knowledge-grounded assistance.

--- a/docs/3rdEye_TECH_SPEC.md
+++ b/docs/3rdEye_TECH_SPEC.md
@@ -1,0 +1,45 @@
+# 3rdEye Technical Specification
+
+3rdEye is a Reality Composer alternative focused on persistent AR creation with Unity 2023.2 LTS, AR Foundation 5.0, and URP. This document condenses the primary objectives, architecture, and phased delivery plan.
+
+## Objectives
+- **Anchors & tracking:** Persistent world anchors, plane detection with boundary visualization, anchor-based hierarchy attachment, and depth-aware occlusion.
+- **Interaction & physics:** Drag-and-drop placement, transform gizmos, physics simulation with collision dynamics and constraints, and robust undo/redo.
+- **Animation & timeline:** Timeline editor with keyframes, multiple tracks, playback controls, and animation baking/export.
+- **Asset pipeline:** Import FBX/OBJ/GLTF/USD (and USDZ/GLB export), automatic LODs, URP material conversion, platform-aware texture compression, and metadata logging.
+- **Rendering:** Dynamic lighting with shadows, selection outlines, occlusion shaders, and URP budgets for mobile.
+- **Cross-platform delivery:** ARKit/ARCore export paths, Addressables for runtime loading, and Mirror-backed collaboration hooks.
+
+## Stack & Integrations
+- **Engine:** Unity 2023.2 LTS + URP + AR Foundation 5.0.
+- **Platform extensions:** ARCore Extensions, ARKit Face Tracking, XR Interaction Toolkit, Addressables, Mirror (networking), Havok physics fallback.
+- **Patterns:** ECS for hot paths, Observer for UI updates, Command for undo/redo, ScriptableObjects for configuration, Addressables for assets.
+- **Input:** Unity Input System with touch gestures (tap, long-press, drag, pinch, rotate, three-finger undo/redo) and keyboard shortcuts for editor use.
+
+## Subsystems
+- **Session & tracking:** ARSessionManager, PlaneDetectionManager (horizontal/vertical, merge distance 0.3m), AnchorManager (persistent IDs, attachment, cleanup), OcclusionRenderer.
+- **Placement & interaction:** HitTestManager, PlacementIndicator, SelectionManager, TransformGizmos (move/rotate/scale, snap), ObjectInspector (transform, physics, material, animation), grouping and duplication.
+- **Physics:** PhysicsManager (timestep 0.02s, CCD for fast movers), collider generation, PhysicsMaterialLibrary (wood/metal/rubber/glass/plastic), constraints (fixed/hinge/spring), physics LOD tiers.
+- **Animation:** TimelineEditor UI, KeyframeRecorder (auto/manual), AnimationPlayer (looping, speed, easing), curve editor, baking to AnimationClip, presets (rotate, bounce, fade, orbit).
+- **Assets:** AssetImporter framework with validators, mesh optimization (weld, degenerate removal, cache-friendly reordering), LOD generator (100/60/30/15 at 0/5/10/20m), texture processing (ASTC/ETC2, mipmaps, 2048 cap), URP material mapping, metadata JSON per import.
+- **Export:** USDZ exporter (iOS) and GLB exporter (Android) with options for compression, texture quality, animation inclusion, and anchor metadata.
+- **Scene persistence:** JSON scene schema (versioned), backups before save, auto-save rotation, migration hooks for forward compatibility.
+- **UI/UX:** Mobile-first layout with safe-area handling, toolbar (select/move/rotate/scale/delete/undo/redo/settings), hierarchy drawer, inspector panel, timeline, context menus, haptic/audio feedback, accessibility (contrast, touch targets, screen reader labels).
+- **Analytics:** Opt-in metrics for performance, feature usage, and error tracking; privacy-first consent flow.
+- **Build & CI:** Git-based flow (main/develop/feature), Unity CLI builds, GitHub Actions/Unity Cloud Build, automated tests (unit/integration/performance), symbol packaging, staged rollouts.
+
+## Delivery Phases (30-Day Outline)
+- **Phase 1 (Days 1-3):** Environment setup; Unity project scaffold per directory tree; core managers (ARSession, Scene, Input, UI); object pooling; “Hello World” plane placement.
+- **Phase 2 (Days 4-7):** AR session robustness, plane detection + visualizers, hit testing, placement indicator, anchor lifecycle and persistence hooks.
+- **Phase 3 (Days 8-12):** Physics system with colliders, materials, forces, constraints, and performance guards (sleeping, LOD); stress testing to 50+ dynamic objects at 60 FPS.
+- **Phase 4 (Days 13-17):** Scene hierarchy UI, selection/transform gizmos, inspector, duplication/deletion/grouping, undo/redo command stack.
+- **Phase 5 (Days 18-22):** Timeline editor, keyframe recording, playback, curve editing, baking/presets, multi-object tracks.
+- **Phase 6 (Days 23-27):** Asset import (FBX/OBJ/GLTF/USD), optimization, asset library UI, USDZ/GLB export with validation and metadata.
+- **Phase 7 (Days 28-30):** Performance polish, bug triage, accessibility sweep, onboarding, documentation, final builds, release checklist.
+
+## Acceptance & Performance Targets
+- 60 FPS target with <35 draw calls and UI frame cost <2ms.
+- Physics stable with 50 dynamic objects; CCD for fast movers; anchor updates batched.
+- Assets validated under 50k tris per mesh, 2048x2048 textures max, import <10s per asset.
+- Undo/redo history up to 50 commands with memory guard; scene save/load includes anchors and animations.
+- Exports validated in AR Quick Look (USDZ) and ARCore Scene Viewer (GLB) with correct materials and anchors.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,73 @@
+# Autonomous AR Development Agent Architecture
+
+## Vision
+An autonomous agent that designs, builds, tests, and deploys spatial-computing features end-to-end. The system fuses retrieval-augmented generation (RAG), reinforcement learning (RL), and simulation feedback loops to continuously improve AR capabilities.
+
+## Core Capabilities
+- **Spatial Computing Expertise:** Scene understanding, SLAM/visual-inertial odometry integration, physics-aware interactions, and real-time rendering constraints.
+- **Advanced AI Tooling:** RAG for grounded code generation and documentation synthesis; RL for policy optimization over tool selections and iterative build actions.
+- **Autonomous DevOps:** Manages repositories, runs build pipelines, executes tests, and deploys artifacts (Unity/XR, native mobile, webXR) with observability hooks.
+- **Self-Optimization:** Tracks rewards from compilation success, test coverage, performance metrics, and user telemetry to refine action policies.
+
+## High-Level Architecture
+```
+[User/Goal] -> [Planner] -> [RAG Synthesizer] -> [Action Policy (RL)]
+            -> [Tool Executor] -> [Build/Test/Deploy Pipelines]
+            -> [Sensors: Logs, Metrics, Scene Simulators]
+            -> [Reward Shaper & Memory Store]
+```
+
+### Planner
+- Decomposes goals into actionable steps.
+- Consults the long-term memory store (vector DB) for prior solutions and design patterns.
+
+### RAG Synthesizer
+- Retrieves code snippets, API references, and research papers.
+- Generates context-aware patches or scene configurations with provenance.
+
+### Action Policy (RL)
+- Chooses tool invocations (edit file, run tests, launch simulator, query docs) based on current state.
+- Reward composed from build success, frame-time budgets, tracking stability, UX metrics, and regression avoidance.
+- Supports offline training (batch rollouts) and online fine-tuning (DQN/actor-critic/GRPO) with constrained safety checks.
+
+### Tool Executor
+- Sandboxed command runner with guardrails (rate limits, secret scrubbing).
+- Integrates with package managers, Unity CLI, mobile build tools, and cloud render farms.
+
+### Build/Test/Deploy Pipelines
+- CI-friendly stages for linting, unit/integration tests, XR rendering benchmarks, and device deployment.
+- Telemetry exporters emit traces, logs, and structured rewards to the memory store for iterative improvement.
+
+### Sensors & Reward Shaper
+- Observability adapters collect:
+  - Runtime metrics: frame time, GPU/CPU load, memory pressure.
+  - Tracking fidelity: reprojection error, feature count, anchor stability.
+  - UX: input latency, interaction errors.
+- Reward shaper fuses metrics with domain rules (e.g., penalize >16ms frames on 60fps targets).
+
+### Memory & Knowledge Graph
+- Vector store for semantic retrieval (code, design docs, runbooks, shaders, URP/HDRP settings).
+- Knowledge graph linking goals, actions, outcomes, and artifacts to enable causal reasoning and reuse.
+
+## Data Flows
+1. **Goal Intake:** Parse requirements -> planner creates task graph.
+2. **Context Build:** RAG pulls relevant code/docs -> synthesizer drafts plan or patch.
+3. **Action Selection:** RL policy ranks candidate tool calls -> executor runs safest/highest value.
+4. **Evaluation:** Build/test/sim outputs -> sensors compute rewards -> memory updated.
+5. **Adaptation:** Policy updated with new rollouts; embeddings refreshed for future retrieval.
+
+## Extensibility Points
+- **New Tools:** Register Unity Editor automation, ARCore/ARKit diagnostics, shader profiling, or custom simulators.
+- **New Modalities:** Incorporate 3D asset generation, gesture synthesis, or physics curriculum learning.
+- **Safety:** Static/dynamic guards, secrets scanning, protected branches, and gated deploy approvals.
+
+## Minimal Stack Recommendations
+- **Language:** Python for orchestration; Rust/C++ bindings for performance-critical CV modules.
+- **RAG:** Local LLM + embedding model; vector DB (e.g., Qdrant/FAISS); document loaders for Unity docs, forums, and codebase.
+- **RL:** PyTorch + RLlib/Lightning; replay buffers for tool trajectories; GRPO/actor-critic for policy learning.
+- **Pipelines:** GitHub Actions/GitLab CI with Unity CLI, mobile build targets, WebXR bundling, and artifact storage.
+
+## Next Steps
+- Implement the agent skeleton (planner, RAG, policy, executor) with plug-in interfaces.
+- Add simulation-backed tests (Unity playmode, headless WebXR) feeding metrics into rewards.
+- Stand up vector DB and experiment tracker (MLflow/W&B) for end-to-end training runs.

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,0 +1,30 @@
+"""Autonomous AR development agent package."""
+
+from .cli import build_orchestrator, register_default_tools
+from .config import AgentConfig
+from .encoding import RegistryBackedActionSpace, SimpleStateEncoder
+from .memory import EchoGenerator, InMemoryStore, SimpleRetriever
+from .pipeline import BuildOrchestrator
+from .planner import Planner, PlanStep
+from .policy import ActionPolicy, PolicyDecision
+from .rag import RetrievalAugmentedGenerator
+from .tools import ToolExecutor, ToolRegistry
+
+__all__ = [
+    "ActionPolicy",
+    "AgentConfig",
+    "BuildOrchestrator",
+    "EchoGenerator",
+    "InMemoryStore",
+    "Planner",
+    "PlanStep",
+    "PolicyDecision",
+    "RegistryBackedActionSpace",
+    "RetrievalAugmentedGenerator",
+    "SimpleRetriever",
+    "SimpleStateEncoder",
+    "ToolExecutor",
+    "ToolRegistry",
+    "build_orchestrator",
+    "register_default_tools",
+]

--- a/src/agent/cli.py
+++ b/src/agent/cli.py
@@ -1,0 +1,76 @@
+"""Command-line entry point to exercise the autonomous AR agent skeleton."""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import List
+
+from .config import AgentConfig
+from .encoding import RegistryBackedActionSpace, SimpleStateEncoder
+from .memory import EchoGenerator, InMemoryStore, SimpleRetriever
+from .pipeline import BuildOrchestrator
+from .planner import Planner
+from .policy import ActionPolicy
+from .rag import RetrievalAugmentedGenerator
+from .tools import ToolExecutor, ToolRegistry
+
+
+def register_default_tools(registry: ToolRegistry) -> None:
+    """Register minimal tools to validate orchestration flow."""
+
+    def noop_tool(payload):
+        return {"success": True, "message": "No-op executed", "build_success": 1.0}
+
+    def summarize_draft(payload):
+        draft: str = payload.get("draft", "")
+        return {
+            "success": True,
+            "message": f"Synthesized draft length {len(draft)}",
+            "test_pass_rate": 1.0,
+        }
+
+    registry.register("noop", noop_tool)
+    registry.register("summarize_draft", summarize_draft)
+
+
+def build_orchestrator(initial_docs: List[str] | None = None) -> BuildOrchestrator:
+    config = AgentConfig()
+    store = InMemoryStore()
+    if initial_docs:
+        store.add(initial_docs)
+    retriever = SimpleRetriever(store)
+    generator = EchoGenerator()
+    rag = RetrievalAugmentedGenerator(retriever=retriever, generator=generator)
+    planner = Planner(memory=store)
+    registry = ToolRegistry()
+    register_default_tools(registry)
+    action_space = RegistryBackedActionSpace(registry.available())
+    policy = ActionPolicy(encoder=SimpleStateEncoder(), action_space=action_space)
+    executor = ToolExecutor(registry)
+    return BuildOrchestrator(config, planner, rag, policy, executor)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run an autonomous AR agent goal.")
+    parser.add_argument("goal", help="High-level goal or feature request")
+    parser.add_argument(
+        "--constraint",
+        action="append",
+        default=[],
+        help="Constraints to consider (repeatable)",
+    )
+    parser.add_argument(
+        "--doc",
+        action="append",
+        default=[],
+        help="Seed documents to prime retrieval",
+    )
+    args = parser.parse_args()
+
+    orchestrator = build_orchestrator(initial_docs=args.doc)
+    result = orchestrator.run_goal(args.goal, constraints=args.constraint)
+    print(json.dumps({"success": result.success, "logs": result.logs, "rewards": result.rewards}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent/config.py
+++ b/src/agent/config.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class AgentConfig:
+    """Configuration for the autonomous AR development agent."""
+
+    model: str = "local-llm"
+    embedding_model: str = "all-MiniLM-L6-v2"
+    vector_store_uri: str = "http://localhost:6333"
+    tools: List[str] = field(default_factory=lambda: ["git", "python", "unity-cli"])
+    reward_weights: Dict[str, float] = field(
+        default_factory=lambda: {
+            "build_success": 1.0,
+            "test_pass_rate": 0.8,
+            "frame_time_budget": 0.6,
+            "tracking_stability": 0.7,
+            "safety": 1.2,
+        }
+    )
+
+    def telemetry_tags(self) -> Dict[str, str]:
+        return {
+            "agent": "holoverse-autonomous-ar",
+            "model": self.model,
+            "embedding_model": self.embedding_model,
+        }

--- a/src/agent/encoding.py
+++ b/src/agent/encoding.py
@@ -1,0 +1,30 @@
+"""Encoders and action spaces for the heuristic policy layer."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass
+class SimpleStateEncoder:
+    """Converts observations into a numeric vector suitable for placeholder policies."""
+
+    def encode(self, observation: Dict) -> List[float]:
+        features: List[float] = []
+        features.append(float(len(observation.get("plan", []))))
+        features.append(float(len(observation.get("constraints", []))))
+        draft_len = len(str(observation.get("draft", "")))
+        features.append(draft_len / 1024.0)
+        goal_len = len(str(observation.get("goal", "")))
+        features.append(goal_len / 256.0)
+        return features or [0.0]
+
+
+@dataclass
+class RegistryBackedActionSpace:
+    """Exposes registry tool names as action candidates."""
+
+    actions_iterable: Iterable[str]
+
+    def actions(self) -> Iterable[str]:
+        return list(self.actions_iterable)

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -1,0 +1,51 @@
+"""Lightweight in-memory components backing the planner and RAG stack."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Sequence
+
+
+@dataclass
+class InMemoryStore:
+    """Minimal memory store for retrieved exemplars and documents."""
+
+    documents: List[str] = field(default_factory=list)
+
+    def add(self, docs: Iterable[str]) -> None:
+        self.documents.extend(docs)
+
+    def retrieve(self, query: str, k: int = 5) -> List[str]:
+        # Naive substring relevance: prefer docs containing tokens from the query.
+        terms = set(query.lower().split())
+        scored: List[tuple[int, str]] = []
+        for doc in self.documents:
+            doc_terms = set(doc.lower().split())
+            score = len(terms.intersection(doc_terms))
+            scored.append((score, doc))
+        scored.sort(key=lambda pair: pair[0], reverse=True)
+        return [doc for score, doc in scored[:k] if score > 0] or self.documents[:k]
+
+
+@dataclass
+class SimpleRetriever:
+    """Retriever wrapper that uses InMemoryStore but exposes a stable interface."""
+
+    store: InMemoryStore
+
+    def embed_and_search(self, query: str, k: int = 5) -> List[str]:
+        return self.store.retrieve(query, k)
+
+    def add_documents(self, documents: Iterable[str]) -> None:
+        self.store.add(documents)
+
+
+@dataclass
+class EchoGenerator:
+    """Generator placeholder that returns a constrained echo of the prompt + citations."""
+
+    max_chars: int = 1200
+
+    def generate(self, prompt: str, context: Sequence[str]) -> str:
+        citations = "\n".join(f"- context[{idx}]" for idx, _ in enumerate(context))
+        trimmed = (prompt[: self.max_chars] + "…") if len(prompt) > self.max_chars else prompt
+        return f"Draft based on prompt:\n{trimmed}\n\nCitations:\n{citations if citations else '- none found'}"

--- a/src/agent/pipeline.py
+++ b/src/agent/pipeline.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable
+
+from .config import AgentConfig
+from .planner import Planner
+from .policy import ActionPolicy
+from .rag import RetrievalAugmentedGenerator
+from .tools import ToolExecutor
+
+
+@dataclass
+class BuildResult:
+    success: bool
+    logs: str
+    rewards: Dict[str, float]
+
+
+class BuildOrchestrator:
+    """Coordinates planning, RAG synthesis, policy selection, and tool execution."""
+
+    def __init__(
+        self,
+        config: AgentConfig,
+        planner: Planner,
+        rag: RetrievalAugmentedGenerator,
+        policy: ActionPolicy,
+        executor: ToolExecutor,
+    ):
+        self.config = config
+        self.planner = planner
+        self.rag = rag
+        self.policy = policy
+        self.executor = executor
+
+    def run_goal(self, goal: str, constraints: Iterable[str] | None = None) -> BuildResult:
+        plan = self.planner.build_plan(goal)
+        synthesis = self.rag.synthesize(goal, constraints or [])
+        decision = self.policy.choose(
+            {
+                "goal": goal,
+                "constraints": list(constraints or []),
+                "plan": [step.description for step in plan],
+                "draft": synthesis,
+            }
+        )
+        tool_output = self.executor.run(decision.action, {"goal": goal, "draft": synthesis})
+        reward = self._shape_reward(tool_output)
+        self.policy.update_with_reward([tool_output], reward)
+        return BuildResult(success=tool_output.get("success", False), logs=str(tool_output), rewards=reward)
+
+    def _shape_reward(self, tool_output: Dict) -> Dict[str, float]:
+        reward = {}
+        for key, weight in self.config.reward_weights.items():
+            signal = float(tool_output.get(key, 0.0))
+            reward[key] = signal * weight
+        reward["total"] = sum(reward.values())
+        return reward

--- a/src/agent/planner.py
+++ b/src/agent/planner.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Protocol
+
+
+class MemoryStore(Protocol):
+    def retrieve(self, query: str, k: int = 5) -> List[str]:
+        ...
+
+
+@dataclass
+class PlanStep:
+    description: str
+    rationale: str
+    dependencies: List[str] | None = None
+
+
+class Planner:
+    """Transforms goals into ordered plan steps with retrieved context."""
+
+    def __init__(self, memory: MemoryStore):
+        self.memory = memory
+
+    def build_plan(self, goal: str) -> List[PlanStep]:
+        context = self.memory.retrieve(goal, k=5)
+        steps = [
+            PlanStep(
+                description="Gather context and constraints",
+                rationale="Ensure actions are grounded in recent decisions and docs.",
+            ),
+            PlanStep(
+                description="Draft implementation or patch",
+                rationale="Use RAG to synthesize changes aligned with constraints.",
+                dependencies=["Gather context and constraints"],
+            ),
+            PlanStep(
+                description="Run build and targeted tests",
+                rationale="Validate correctness and performance early.",
+                dependencies=["Draft implementation or patch"],
+            ),
+            PlanStep(
+                description="Evaluate telemetry and update policy",
+                rationale="Feed rewards back into RL policy for continual improvement.",
+                dependencies=["Run build and targeted tests"],
+            ),
+        ]
+        if context:
+            steps.insert(
+                1,
+                PlanStep(
+                    description="Integrate retrieved exemplars",
+                    rationale="Ground plan on nearest-neighbor solutions and patterns.",
+                    dependencies=["Gather context and constraints"],
+                ),
+            )
+        return steps

--- a/src/agent/policy.py
+++ b/src/agent/policy.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Protocol
+
+
+class StateEncoder(Protocol):
+    def encode(self, observation: Dict) -> List[float]:
+        ...
+
+
+class ActionSpace(Protocol):
+    def actions(self) -> Iterable[str]:
+        ...
+
+
+@dataclass
+class PolicyDecision:
+    action: str
+    score: float
+    rationale: str
+
+
+class ActionPolicy:
+    """Scores available actions using a learned policy."""
+
+    def __init__(self, encoder: StateEncoder, action_space: ActionSpace):
+        self.encoder = encoder
+        self.action_space = action_space
+
+    def choose(self, observation: Dict) -> PolicyDecision:
+        encoded_state = self.encoder.encode(observation)
+        candidates = list(self.action_space.actions())
+        scored = self._score(encoded_state, candidates)
+        scored.sort(key=lambda item: item.score, reverse=True)
+        return scored[0]
+
+    def _score(self, state: List[float], candidates: List[str]) -> List[PolicyDecision]:
+        # Placeholder scoring: favors earlier actions but can be replaced by RL outputs.
+        decisions: List[PolicyDecision] = []
+        for idx, action in enumerate(candidates):
+            score = 1.0 / (1 + idx)
+            rationale = "Heuristic score; replace with policy network inference"
+            decisions.append(PolicyDecision(action=action, score=score, rationale=rationale))
+        return decisions
+
+    def update_with_reward(self, trajectories: Iterable[Dict], reward: float) -> None:
+        # Hook for RL algorithms (e.g., actor-critic, GRPO) to refine the policy.
+        _ = trajectories, reward
+        # Training loop intentionally omitted in skeleton.

--- a/src/agent/rag.py
+++ b/src/agent/rag.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Protocol, Sequence
+
+
+class Retriever(Protocol):
+    def embed_and_search(self, query: str, k: int = 5) -> List[str]:
+        ...
+
+    def add_documents(self, documents: Iterable[str]) -> None:
+        ...
+
+
+class Generator(Protocol):
+    def generate(self, prompt: str, context: Sequence[str]) -> str:
+        ...
+
+
+@dataclass
+class RetrievalAugmentedGenerator:
+    retriever: Retriever
+    generator: Generator
+
+    def retrieve(self, query: str, k: int = 5) -> List[str]:
+        return self.retriever.embed_and_search(query, k=k)
+
+    def synthesize(self, goal: str, constraints: Sequence[str] | None = None) -> str:
+        context = self.retrieve(goal, k=8)
+        prompt = self._build_prompt(goal, constraints or [], context)
+        return self.generator.generate(prompt, context)
+
+    def _build_prompt(self, goal: str, constraints: Sequence[str], context: Sequence[str]) -> str:
+        constraint_block = "\n".join(f"- {c}" for c in constraints)
+        context_block = "\n".join(context)
+        return (
+            "Goal:\n" + goal + "\n\n"
+            "Constraints:\n" + constraint_block + "\n\n"
+            "Context:\n" + context_block + "\n\n"
+            "Return a concise plan or patch with citations to the provided context when applicable."
+        )

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Iterable, List
+
+ToolFn = Callable[[Dict], Dict]
+
+
+@dataclass
+class ToolRegistry:
+    tools: Dict[str, ToolFn] = field(default_factory=dict)
+
+    def register(self, name: str, fn: ToolFn) -> None:
+        self.tools[name] = fn
+
+    def available(self) -> Iterable[str]:
+        return self.tools.keys()
+
+    def invoke(self, name: str, payload: Dict) -> Dict:
+        if name not in self.tools:
+            raise KeyError(f"Tool {name} is not registered")
+        return self.tools[name](payload)
+
+
+class ToolExecutor:
+    """Executes registered tools and tracks outcomes."""
+
+    def __init__(self, registry: ToolRegistry | None = None):
+        self.registry = registry or ToolRegistry()
+        self.invocation_log: List[Dict] = []
+
+    def run(self, tool_name: str, payload: Dict) -> Dict:
+        result = self.registry.invoke(tool_name, payload)
+        self.invocation_log.append({"tool": tool_name, "payload": payload, "result": result})
+        return result
+
+    def summary(self) -> List[Dict]:
+        return list(self.invocation_log)


### PR DESCRIPTION
## Summary
- add runnable CLI harness wiring planner, RAG, policy, and tools for the autonomous agent
- provide simple in-memory retriever/generator, encoder, and registry-backed action space
- document CLI usage in README and expose new utilities via package exports

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694083313fc88329a1b457ba4f750ce7)